### PR TITLE
Card bottom hover fix

### DIFF
--- a/src/scss/_content-card.scss
+++ b/src/scss/_content-card.scss
@@ -1,29 +1,27 @@
-  .cards {
-      position: relative;
-      padding: 0 $content-margin;
-      width: $content-width;
+.cards {
+  padding: 0 $content-margin;
+  position: relative;
+  width: $content-width;
 
-    @include desktop-up {
-      max-width: 1200px;
-    }
+  @include desktop-up {
+    max-width: 1200px;
+  }
 }
 
 .card {
-  border-color: $gray-light;
+  border: solid 1px $gray-light;
   border-style: solid;
   border-top-left-radius: $border-radius;
   border-top-right-radius: $border-radius;
-  border: solid 1px $gray-light;
-  border-bottom: solid 4px $tf-blue;
   display: flex;
   flex-direction: column;
-  transition-property: opacity;
   transition-duration: .3s;
+  transition-property: background;
   transition-timing-function: ease-in ease-out;
 
   &:hover {
+    background: linear-gradient(to top, $tf-blue, $tf-blue 5px, $background-color 5px, $background-color);
     cursor: pointer;
-    opacity: .75;
   }
 
   > *:first-child {
@@ -51,12 +49,11 @@
   transition-timing-function: ease-in ease-out;
 
   img {
-    border-radius: inherit;
+    border-radius: $border-radius $border-radius 0 0;
     display: block;
     height: auto;
     width: 100%;
-    border-radius: $border-radius $border-radius 0 0;
-    }
+  }
 
   &:hover {
     opacity: .75;
@@ -67,13 +64,12 @@
   padding: 1em 1em 1.5rem;
 
   h2 {
-    margin-bottom: .6rem;
     font-size: 1.4rem;
+    margin-bottom: .6rem;
   }
 
   p {
-    line-height: 1.3;
     font-size: .9rem;
+    line-height: 1.3;
   }
-
 }

--- a/src/scss/_content-card.scss
+++ b/src/scss/_content-card.scss
@@ -48,15 +48,27 @@
   transition-property: opacity;
   transition-timing-function: ease-in ease-out;
 
+  &::before {
+    background: $background-color;
+    bottom: 0;
+    content: '';
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: opacity .2s ease-in-out;
+  }
+
+  &:hover::before {
+    opacity: .1;
+  }
+
   img {
     border-radius: $border-radius $border-radius 0 0;
     display: block;
     height: auto;
     width: 100%;
-  }
-
-  &:hover {
-    opacity: .75;
   }
 }
 

--- a/src/scss/_content-card.scss
+++ b/src/scss/_content-card.scss
@@ -40,8 +40,12 @@
 
 .card .image {
   background: $gray-lighter;
+  background-position: center;
+  background-size: cover;
+  border-radius: $border-radius $border-radius 0 0;
   display: block;
-  flex: 0 0 auto;
+  flex: 1 0 auto;
+  min-height: 250px;
   padding: 0;
   position: relative;
   transition-duration: .3s;
@@ -63,16 +67,10 @@
   &:hover::before {
     opacity: .1;
   }
-
-  img {
-    border-radius: $border-radius $border-radius 0 0;
-    display: block;
-    height: auto;
-    width: 100%;
-  }
 }
 
 .content {
+  flex: 0 0 auto;
   padding: 1em 1em 1.5rem;
 
   h2 {

--- a/src/scss/_content-card.scss
+++ b/src/scss/_content-card.scss
@@ -75,11 +75,12 @@
 
   h2 {
     font-size: 1.4rem;
-    margin-bottom: .6rem;
+    line-height: 1.5rem;
+    margin-bottom: 1.5rem;
   }
 
   p {
     font-size: .9rem;
-    line-height: 1.3;
+    line-height: 1.5rem;
   }
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -581,8 +581,7 @@
       <br>
       <div class="container row cards">
         <div class="card">
-          <div class="image">
-            <img src="/images/complexity.png">
+          <div class="image" style="background-image:url('/images/complexity.png')">
           </div>
           <div class="content">
             <h2>A Content Title Goes Here</h2>
@@ -592,8 +591,7 @@
           </div>
         </div>
         <div class="card">
-          <div class="image">
-            <img src="/images/jets.gif">
+          <div class="image" style="background-image:url('/images/jets.gif')">
           </div>
           <div class="content">
             <h2>Another Content Title Goes Right Here</h2>
@@ -603,8 +601,7 @@
           </div>
         </div>
         <div class="card">
-          <div class="image">
-            <img src="/images/wind.jpg">
+          <div class="image" style="background-image:url('/images/wind.jpg')">
           </div>
           <div class="content">
             <h2>3rd Content Title</h2>
@@ -616,8 +613,7 @@
       </div>
       <div class="container row cards">
         <div class="card">
-          <div class="image">
-            <img src="/images/capitol.png">
+          <div class="image" style="background-image:url('/images/capitol.png')">
           </div>
           <div class="content">
             <h2>Another Content Title That's A Little Bit Longer Goes Right Here</h2>
@@ -627,8 +623,7 @@
           </div>
         </div>
         <div class="card bottom-border">
-          <div class="image">
-            <img src="/images/oregon.png">
+          <div class="image" style="background-image:url('/images/oregon.png')">
           </div>
           <div class="content">
             <h2>3rd Content Title</h2>


### PR DESCRIPTION
Fixes #19 

Changes functionality of cards to use backgrounds on the `.image` div with a `min-height` instead of using `img` elements. This matches the previous WordPress theme prototype. The `background-image` style needs to be set on the `div` itself.

Changed some flexbox and line-height properties to align text to baselines across cards in a row.
